### PR TITLE
Implement first Yjs transport slice

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -21,6 +21,7 @@ The first implementation target is Yjs, but the API should be shaped so the repo
 - buffered update publishing
 - checkpoint publishing and replay helpers
 - host hooks for signer acceptance policy
+- a transport adapter contract that does not require a specific Nostr client library
 
 `nostr-crdt` should not provide:
 
@@ -29,19 +30,22 @@ The first implementation target is Yjs, but the API should be shaped so the repo
 - moderation workflow
 - bakedown or GitHub PR logic
 
-## Expected primitives
+## First implementation slice
 
-The library should eventually expose small primitives shaped roughly like:
+The current implementation exposes:
 
 - `createRoomId(namespace, documentId)`
-- `encodeUpdateMessage(...)`
-- `decodeMessage(...)`
-- `subscribeDocument(...)`
-- `publishUpdate(...)`
-- `requestCheckpoint(...)`
-- `applyReplay(...)`
+- `createDocumentFilters(...)`
+- `createUnsignedEvent(...)`
+- `decodeEvent(...)`
+- `createYjsSync(...)`
 
-These names are placeholders, not frozen API.
+The higher-level sync object is responsible for:
+
+- replay
+- buffered update publishing
+- checkpoint publishing
+- checkpoint requests
 
 ## Host responsibilities
 
@@ -75,3 +79,15 @@ Required test shapes:
 - two-writer convergence
 - checkpoint plus tail replay
 - ignored update from a host-rejected signer
+
+## Transport adapter
+
+The first implementation should accept a small adapter rather than importing a full Nostr client stack.
+
+Expected adapter shape:
+
+- `query(filters) -> Promise<event[]>`
+- `subscribe(filters, onEvent) -> unsubscribe | Promise<unsubscribe>`
+- `publish(event) -> Promise<event>`
+
+This keeps the core library browser-first and easy to test.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -58,11 +58,11 @@ The exact Nostr kind may be application-configurable. The transport must support
 Recommended tags:
 
 - `["t", "crdt"]`
-- `["app", "<namespace>"]`
-- `["doc", "<document-id>"]`
-- `["msg", "update" | "checkpoint" | "checkpoint-request"]`
-- `["codec", "yjs-update-v1"]`
-- `["checkpoint", "<checkpoint-id>"]` when applicable
+- `["n", "<namespace>"]`
+- `["d", "<room-id>"]`
+- `["m", "update" | "checkpoint" | "checkpoint-request"]`
+- `["c", "yjs-update-v1"]`
+- `["x", "<checkpoint-id>"]` when applicable
 
 The event `pubkey` is the signer identity. The transport does not decide whether that signer is trusted; the host application does.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,42 @@ This repo starts as a protocol and implementation-plan scaffold. The next step i
 - optional checkpoint messages
 - in-memory transport tests
 
+The first implementation slice is now present:
+
+- Yjs document sync with buffered update publishing
+- checkpoint plus tail replay
+- host-provided acceptance hook
+- in-memory transport tests
+
+## First API slice
+
+```js
+import * as Y from "yjs";
+import { createRoomId, createYjsSync } from "nostr-crdt";
+
+const doc = new Y.Doc();
+const roomId = createRoomId("true-cost", "page:home");
+
+const sync = createYjsSync({
+  doc,
+  namespace: "true-cost",
+  roomId,
+  transport,
+  signer,
+  acceptEvent(event, decoded) {
+    return trustedAdminSet.has(decoded.event.pubkey);
+  },
+});
+
+await sync.initialize();
+```
+
+The transport adapter is intentionally small:
+
+- `query(filters)`
+- `subscribe(filters, onEvent)`
+- `publish(event)`
+
 ## Documents
 
 - [PROTOCOL.md](./PROTOCOL.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,12 @@
 # Roadmap
 
-## First implementation
+## Completed
 
-- define exact event codec for Yjs update and checkpoint messages
-- implement minimal browser-first transport package
-- add in-memory relay test harness
-- support signer validation hook from host applications
-- support checkpoint replay plus tail updates
+- exact event codec for Yjs update and checkpoint messages
+- minimal browser-first transport package
+- in-memory relay test harness
+- signer validation hook from host applications
+- checkpoint replay plus tail updates
 
 ## Next
 
@@ -14,6 +14,7 @@
 - document compaction heuristics
 - optional awareness channel
 - app examples that do not pull in a full framework by default
+- first `nostr-site` integration against one collaborative unit type
 
 ## Later
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,64 @@
+{
+  "name": "nostr-crdt",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nostr-crdt",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "yjs": "13.6.27"
+      }
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.27",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
+      "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "check": "node --check src/index.js"
+    "check": "node --check src/index.js && node --check src/codec.js && node --check src/yjs-sync.js && node --check test/helpers/in-memory-transport.js && node --check test/nostr-crdt.test.js",
+    "test": "node --test test/nostr-crdt.test.js"
+  },
+  "dependencies": {
+    "yjs": "13.6.27"
   }
 }

--- a/src/codec.js
+++ b/src/codec.js
@@ -1,0 +1,221 @@
+export const PROTOCOL_VERSION = 1;
+export const YJS_UPDATE_CODEC = "yjs-update-v1";
+export const DEFAULT_EVENT_KIND = 31178;
+
+export function createRoomId(namespace, documentId) {
+  const app = normalizeToken(namespace, "app");
+  const doc = normalizeDocumentId(documentId);
+  return `${app}:${doc}`;
+}
+
+export function createDocumentFilters({
+  kind = DEFAULT_EVENT_KIND,
+  namespace,
+  roomId,
+}) {
+  const app = normalizeToken(namespace, "app");
+  const room = normalizeDocumentId(roomId);
+
+  return [
+    createFilter(kind, app, room, "checkpoint"),
+    createFilter(kind, app, room, "update"),
+    createFilter(kind, app, room, "checkpoint-request"),
+  ];
+}
+
+export function createUnsignedEvent({
+  kind = DEFAULT_EVENT_KIND,
+  namespace,
+  roomId,
+  messageType,
+  payloadBytes = new Uint8Array(),
+  checkpointId = "",
+  createdAt = unixNow(),
+  meta = {},
+}) {
+  const app = normalizeToken(namespace, "app");
+  const room = normalizeDocumentId(roomId);
+  const msg = normalizeMessageType(messageType);
+  const content = {
+    v: PROTOCOL_VERSION,
+    doc: room,
+    msg,
+    codec: YJS_UPDATE_CODEC,
+    payload: toBase64(payloadBytes),
+    baseCheckpoint: String(checkpointId || "").trim(),
+    meta: isPlainObject(meta) ? meta : {},
+  };
+
+  const tags = [
+    ["t", "crdt"],
+    ["n", app],
+    ["d", room],
+    ["m", msg],
+    ["c", YJS_UPDATE_CODEC],
+  ];
+
+  if (content.baseCheckpoint) tags.push(["x", content.baseCheckpoint]);
+
+  return {
+    kind: Number(kind),
+    created_at: Number(createdAt),
+    tags,
+    content: JSON.stringify(content),
+  };
+}
+
+export function decodeEvent(event, expectations = {}) {
+  if (!event || typeof event !== "object") {
+    throw new Error("Event must be an object.");
+  }
+
+  const parsed = parseJson(event.content);
+  if (!parsed || parsed.v !== PROTOCOL_VERSION) {
+    throw new Error("Event payload version is unsupported.");
+  }
+
+  const tags = createTagMap(event.tags);
+  const namespace = firstTag(tags, "n");
+  const roomId = firstTag(tags, "d");
+  const messageType = firstTag(tags, "m");
+  const codec = firstTag(tags, "c");
+  const checkpointId = firstTag(tags, "x") || String(parsed.baseCheckpoint || "").trim();
+
+  if (firstTag(tags, "t") !== "crdt") throw new Error("Event is not a CRDT message.");
+  if (!namespace) throw new Error("CRDT event is missing namespace.");
+  if (!roomId) throw new Error("CRDT event is missing room id.");
+  if (!messageType) throw new Error("CRDT event is missing message type.");
+  if (codec !== YJS_UPDATE_CODEC || parsed.codec !== YJS_UPDATE_CODEC) {
+    throw new Error("CRDT event codec is unsupported.");
+  }
+
+  if (expectations.namespace && namespace !== normalizeToken(expectations.namespace, "app")) {
+    throw new Error("CRDT event namespace does not match.");
+  }
+
+  if (expectations.roomId && roomId !== normalizeDocumentId(expectations.roomId)) {
+    throw new Error("CRDT event room id does not match.");
+  }
+
+  return {
+    event,
+    namespace,
+    roomId,
+    messageType: normalizeMessageType(messageType),
+    codec,
+    checkpointId,
+    createdAt: Number(event.created_at || 0),
+    pubkey: String(event.pubkey || "").trim(),
+    payloadBytes: fromBase64(String(parsed.payload || "")),
+    payloadBase64: String(parsed.payload || ""),
+    meta: isPlainObject(parsed.meta) ? parsed.meta : {},
+  };
+}
+
+export function sortEventsAscending(events) {
+  return [...events].sort(compareEventsAscending);
+}
+
+export function compareEventsAscending(left, right) {
+  const leftTime = Number(left?.created_at || 0);
+  const rightTime = Number(right?.created_at || 0);
+  if (leftTime !== rightTime) return leftTime - rightTime;
+  return String(left?.id || "").localeCompare(String(right?.id || ""));
+}
+
+export function normalizeToken(value, fallback = "") {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._:-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (normalized) return normalized;
+  if (fallback) return fallback;
+  throw new Error("Expected a non-empty token.");
+}
+
+export function normalizeDocumentId(value) {
+  return normalizeToken(value, "document");
+}
+
+export function normalizeMessageType(value) {
+  const normalized = normalizeToken(value, "update");
+  if (
+    normalized !== "update" &&
+    normalized !== "checkpoint" &&
+    normalized !== "checkpoint-request"
+  ) {
+    throw new Error(`Unsupported CRDT message type: ${normalized}`);
+  }
+  return normalized;
+}
+
+function createFilter(kind, namespace, roomId, messageType) {
+  return {
+    kinds: [Number(kind)],
+    "#t": ["crdt"],
+    "#n": [namespace],
+    "#d": [roomId],
+    "#m": [normalizeMessageType(messageType)],
+  };
+}
+
+function createTagMap(tags) {
+  const tagMap = new Map();
+  for (const tag of Array.isArray(tags) ? tags : []) {
+    if (!Array.isArray(tag) || tag.length < 2) continue;
+    const key = String(tag[0] || "").trim();
+    if (!key) continue;
+    const list = tagMap.get(key) || [];
+    list.push(String(tag[1] || "").trim());
+    tagMap.set(key, list);
+  }
+  return tagMap;
+}
+
+function firstTag(tagMap, key) {
+  const values = tagMap.get(key);
+  return values?.[0] || "";
+}
+
+function parseJson(value) {
+  try {
+    const parsed = JSON.parse(String(value || ""));
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isPlainObject(value) {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export function unixNow() {
+  return Math.floor(Date.now() / 1000);
+}
+
+export function toBase64(bytes) {
+  const value = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes || []);
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value).toString("base64");
+  }
+  let binary = "";
+  for (const byte of value) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+export function fromBase64(value) {
+  const source = String(value || "");
+  if (!source) return new Uint8Array();
+  if (typeof Buffer !== "undefined") {
+    return new Uint8Array(Buffer.from(source, "base64"));
+  }
+  const binary = atob(source);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,19 @@
-/**
- * Docs-first scaffold.
- *
- * The first real implementation should expose:
- * - room identity helpers
- * - event codec helpers
- * - replay helpers
- * - buffered update publishing
- * - checkpoint helpers
- * - host-provided authorization hooks
- */
+export {
+  DEFAULT_EVENT_KIND,
+  PROTOCOL_VERSION,
+  YJS_UPDATE_CODEC,
+  compareEventsAscending,
+  createDocumentFilters,
+  createRoomId,
+  createUnsignedEvent,
+  decodeEvent,
+  fromBase64,
+  normalizeDocumentId,
+  normalizeMessageType,
+  normalizeToken,
+  sortEventsAscending,
+  toBase64,
+  unixNow,
+} from "./codec.js";
 
-export const PROTOCOL_VERSION = 1;
-
-export function describeProtocol() {
-  return {
-    version: PROTOCOL_VERSION,
-    name: "nostr-crdt",
-    focus: "CRDT transport over Nostr",
-    initialTarget: "Yjs",
-  };
-}
+export { createYjsSync, getRemoteOrigin, YjsNostrSync } from "./yjs-sync.js";

--- a/src/yjs-sync.js
+++ b/src/yjs-sync.js
@@ -1,0 +1,260 @@
+import * as Y from "yjs";
+import {
+  DEFAULT_EVENT_KIND,
+  createDocumentFilters,
+  createUnsignedEvent,
+  decodeEvent,
+  sortEventsAscending,
+} from "./codec.js";
+
+const REMOTE_ORIGIN = Symbol("nostr-crdt-remote");
+
+export function createYjsSync(options) {
+  return new YjsNostrSync(options);
+}
+
+export class YjsNostrSync {
+  constructor({
+    doc,
+    namespace,
+    roomId,
+    transport,
+    signer,
+    kind = DEFAULT_EVENT_KIND,
+    bufferMs = 100,
+    acceptEvent = () => true,
+    onCheckpointRequest = null,
+  }) {
+    if (!(doc instanceof Y.Doc)) throw new Error("doc must be a Y.Doc.");
+    if (!transport || typeof transport.query !== "function" || typeof transport.publish !== "function") {
+      throw new Error("transport must provide query() and publish().");
+    }
+    if (typeof transport.subscribe !== "function") {
+      throw new Error("transport must provide subscribe().");
+    }
+    if (!signer || typeof signer.sign !== "function" || !String(signer.pubkey || "").trim()) {
+      throw new Error("signer must provide pubkey and sign().");
+    }
+
+    this.doc = doc;
+    this.namespace = namespace;
+    this.roomId = roomId;
+    this.kind = Number(kind);
+    this.transport = transport;
+    this.signer = signer;
+    this.bufferMs = Math.max(0, Number(bufferMs) || 0);
+    this.acceptEvent = acceptEvent;
+    this.onCheckpointRequest = onCheckpointRequest;
+
+    this.filters = createDocumentFilters({
+      kind: this.kind,
+      namespace: this.namespace,
+      roomId: this.roomId,
+    });
+
+    this.pendingUpdates = [];
+    this.flushTimer = null;
+    this.unsubscribe = null;
+    this.initialized = false;
+    this.destroyed = false;
+    this.seenEventIds = new Set();
+
+    this.handleDocumentUpdate = this.handleDocumentUpdate.bind(this);
+    this.handleTransportEvent = this.handleTransportEvent.bind(this);
+
+    this.doc.on("update", this.handleDocumentUpdate);
+  }
+
+  async initialize() {
+    if (this.destroyed) throw new Error("Cannot initialize a destroyed sync.");
+    if (this.initialized) return this;
+
+    const localStateBeforeReplay = Y.encodeStateAsUpdate(this.doc);
+    const unsubscribe = await this.transport.subscribe(this.filters, this.handleTransportEvent);
+    this.unsubscribe = typeof unsubscribe === "function" ? unsubscribe : () => {};
+
+    const replayEvents = await this.transport.query(this.filters);
+    const remoteState = await this.applyReplay(replayEvents);
+    const remoteVector = Y.encodeStateVectorFromUpdate(remoteState);
+    const missingOnRemote = Y.diffUpdate(Y.encodeStateAsUpdate(this.doc), remoteVector);
+
+    if (hasMeaningfulUpdate(localStateBeforeReplay) && hasMeaningfulUpdate(missingOnRemote)) {
+      this.pendingUpdates.push(missingOnRemote);
+      await this.flush();
+    }
+
+    this.initialized = true;
+    return this;
+  }
+
+  async flush() {
+    if (!this.pendingUpdates.length) return null;
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+
+    const update =
+      this.pendingUpdates.length === 1
+        ? this.pendingUpdates[0]
+        : Y.mergeUpdates(this.pendingUpdates);
+
+    this.pendingUpdates = [];
+    return this.publishMessage("update", update);
+  }
+
+  async publishCheckpoint(meta = {}) {
+    const update = Y.encodeStateAsUpdate(this.doc);
+    return this.publishMessage("checkpoint", update, meta);
+  }
+
+  async requestCheckpoint(meta = {}) {
+    return this.publishMessage("checkpoint-request", new Uint8Array(), meta);
+  }
+
+  destroy() {
+    this.destroyed = true;
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    this.pendingUpdates = [];
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+    this.doc.off("update", this.handleDocumentUpdate);
+  }
+
+  async applyReplay(events) {
+    const decoded = await this.decodeAccepted(events);
+    const checkpoints = decoded.filter((item) => item.messageType === "checkpoint");
+    const updates = decoded.filter((item) => item.messageType === "update");
+    const remoteDoc = new Y.Doc();
+
+    const latestCheckpoint = checkpoints.length ? checkpoints[checkpoints.length - 1] : null;
+    if (latestCheckpoint) {
+      this.applyUpdate(latestCheckpoint.payloadBytes);
+      Y.applyUpdate(remoteDoc, latestCheckpoint.payloadBytes, REMOTE_ORIGIN);
+    }
+
+    const checkpointCutoff = latestCheckpoint
+      ? sortEventsAscending(events).findIndex((event) => event.id === latestCheckpoint.event.id)
+      : -1;
+
+    const orderedEvents = sortEventsAscending(events);
+    for (let index = 0; index < orderedEvents.length; index += 1) {
+      if (index <= checkpointCutoff) continue;
+      const event = orderedEvents[index];
+      const decodedEvent = updates.find((item) => item.event.id === event.id);
+      if (!decodedEvent) continue;
+      this.applyUpdate(decodedEvent.payloadBytes);
+      Y.applyUpdate(remoteDoc, decodedEvent.payloadBytes, REMOTE_ORIGIN);
+    }
+
+    return Y.encodeStateAsUpdate(remoteDoc);
+  }
+
+  handleDocumentUpdate(update, origin) {
+    if (this.destroyed || origin === REMOTE_ORIGIN) return;
+    this.pendingUpdates.push(update);
+
+    if (this.bufferMs === 0) {
+      void this.flush();
+      return;
+    }
+
+    if (this.flushTimer) clearTimeout(this.flushTimer);
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      void this.flush();
+    }, this.bufferMs);
+  }
+
+  async handleTransportEvent(event) {
+    if (this.destroyed) return;
+    if (event?.id && this.seenEventIds.has(event.id)) return;
+
+    let decoded;
+    try {
+      decoded = decodeEvent(event, {
+        namespace: this.namespace,
+        roomId: this.roomId,
+      });
+    } catch {
+      return;
+    }
+
+    const accepted = await this.acceptEvent(event, decoded);
+    if (!accepted) return;
+
+    if (event.id) this.seenEventIds.add(event.id);
+
+    if (decoded.messageType === "checkpoint-request") {
+      if (typeof this.onCheckpointRequest === "function") {
+        await this.onCheckpointRequest({ event, decoded, sync: this });
+      }
+      return;
+    }
+
+    this.applyUpdate(decoded.payloadBytes);
+  }
+
+  applyUpdate(update) {
+    if (!(update instanceof Uint8Array) || update.length === 0) return;
+    Y.applyUpdate(this.doc, update, REMOTE_ORIGIN);
+  }
+
+  async publishMessage(messageType, payloadBytes, meta = {}) {
+    const unsignedEvent = createUnsignedEvent({
+      kind: this.kind,
+      namespace: this.namespace,
+      roomId: this.roomId,
+      messageType,
+      payloadBytes,
+      meta,
+    });
+
+    const signedEvent = await this.signer.sign({
+      ...unsignedEvent,
+      pubkey: this.signer.pubkey,
+    });
+
+    const published = await this.transport.publish(signedEvent);
+    if (published?.id) this.seenEventIds.add(published.id);
+    return published;
+  }
+
+  async decodeAccepted(events) {
+    const ordered = sortEventsAscending(Array.isArray(events) ? events : []);
+    const accepted = [];
+
+    for (const event of ordered) {
+      if (event?.id && this.seenEventIds.has(event.id)) continue;
+
+      let decoded;
+      try {
+        decoded = decodeEvent(event, {
+          namespace: this.namespace,
+          roomId: this.roomId,
+        });
+      } catch {
+        continue;
+      }
+
+      if (!(await this.acceptEvent(event, decoded))) continue;
+      if (event.id) this.seenEventIds.add(event.id);
+      accepted.push(decoded);
+    }
+
+    return accepted;
+  }
+}
+
+export function getRemoteOrigin() {
+  return REMOTE_ORIGIN;
+}
+
+function hasMeaningfulUpdate(update) {
+  return update instanceof Uint8Array && update.length > 2;
+}

--- a/test/helpers/in-memory-transport.js
+++ b/test/helpers/in-memory-transport.js
@@ -1,0 +1,111 @@
+import { createHash } from "node:crypto";
+
+export function createInMemoryTransport() {
+  const events = [];
+  const subscriptions = new Set();
+
+  return {
+    async query(filters) {
+      const list = normalizeFilters(filters);
+      return events.filter((event) => list.some((filter) => matchesFilter(event, filter)));
+    },
+
+    async publish(event) {
+      const normalized = normalizeEvent(event, events.length);
+      events.push(normalized);
+      queueMicrotask(() => {
+        for (const subscription of subscriptions) {
+          if (subscription.filters.some((filter) => matchesFilter(normalized, filter))) {
+            subscription.onEvent(normalized);
+          }
+        }
+      });
+      return normalized;
+    },
+
+    async subscribe(filters, onEvent) {
+      const entry = {
+        filters: normalizeFilters(filters),
+        onEvent,
+      };
+      subscriptions.add(entry);
+      return () => subscriptions.delete(entry);
+    },
+
+    getEvents() {
+      return events.slice();
+    },
+  };
+}
+
+export function createTestSigner(label) {
+  const pubkey = `pubkey:${String(label || "signer").trim()}`;
+  return {
+    pubkey,
+    async sign(event) {
+      const body = JSON.stringify({
+        kind: event.kind,
+        created_at: event.created_at,
+        pubkey,
+        tags: event.tags,
+        content: event.content,
+      });
+      const id = sha256(body);
+      return {
+        ...event,
+        pubkey,
+        id,
+        sig: `sig:${id}`,
+      };
+    },
+  };
+}
+
+function normalizeFilters(filters) {
+  return Array.isArray(filters) ? filters.filter(Boolean) : [filters].filter(Boolean);
+}
+
+function normalizeEvent(event, sequence) {
+  const pubkey = String(event.pubkey || "").trim();
+  const body = JSON.stringify({
+    kind: event.kind,
+    created_at: event.created_at,
+    pubkey,
+    tags: event.tags,
+    content: event.content,
+    sequence,
+  });
+  const id = String(event.id || sha256(body));
+  return {
+    ...event,
+    pubkey,
+    id,
+    sig: String(event.sig || `sig:${id}`),
+  };
+}
+
+function matchesFilter(event, filter) {
+  if (!filter || typeof filter !== "object") return false;
+  if (Array.isArray(filter.kinds) && !filter.kinds.includes(Number(event.kind))) return false;
+  if (Array.isArray(filter.authors) && !filter.authors.includes(String(event.pubkey || ""))) return false;
+  if (Array.isArray(filter.ids) && !filter.ids.includes(String(event.id || ""))) return false;
+  if (Number.isFinite(filter.since) && Number(event.created_at || 0) < Number(filter.since)) return false;
+  if (Number.isFinite(filter.until) && Number(event.created_at || 0) > Number(filter.until)) return false;
+
+  for (const [key, values] of Object.entries(filter)) {
+    if (!key.startsWith("#")) continue;
+    const tagKey = key.slice(1);
+    const tagValues = (Array.isArray(event.tags) ? event.tags : [])
+      .filter((tag) => Array.isArray(tag) && tag[0] === tagKey)
+      .map((tag) => String(tag[1] || ""));
+    if (!Array.isArray(values) || !values.some((value) => tagValues.includes(String(value)))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(String(value || "")).digest("hex");
+}

--- a/test/nostr-crdt.test.js
+++ b/test/nostr-crdt.test.js
@@ -1,0 +1,213 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as Y from "yjs";
+
+import {
+  createDocumentFilters,
+  createRoomId,
+  createUnsignedEvent,
+  createYjsSync,
+  decodeEvent,
+} from "../src/index.js";
+import { createInMemoryTransport, createTestSigner } from "./helpers/in-memory-transport.js";
+
+test("one writer syncs to another client over replay and live updates", async () => {
+  const transport = createInMemoryTransport();
+  const roomId = createRoomId("demo", "page:home");
+
+  const aliceDoc = new Y.Doc();
+  const bobDoc = new Y.Doc();
+
+  aliceDoc.getText("body").insert(0, "hello");
+
+  const alice = createYjsSync({
+    doc: aliceDoc,
+    namespace: "demo",
+    roomId,
+    transport,
+    signer: createTestSigner("alice"),
+    bufferMs: 0,
+  });
+
+  await alice.initialize();
+  await alice.flush();
+
+  const bob = createYjsSync({
+    doc: bobDoc,
+    namespace: "demo",
+    roomId,
+    transport,
+    signer: createTestSigner("bob"),
+    bufferMs: 0,
+  });
+
+  await bob.initialize();
+  assert.equal(bobDoc.getText("body").toString(), "hello");
+
+  aliceDoc.getText("body").insert(aliceDoc.getText("body").length, " world");
+  await alice.flush();
+  await tick();
+
+  assert.equal(bobDoc.getText("body").toString(), "hello world");
+
+  alice.destroy();
+  bob.destroy();
+});
+
+test("two writers converge on shared state", async () => {
+  const transport = createInMemoryTransport();
+  const roomId = createRoomId("demo", "post:alpha");
+
+  const aliceDoc = new Y.Doc();
+  const bobDoc = new Y.Doc();
+
+  const alice = createYjsSync({
+    doc: aliceDoc,
+    namespace: "demo",
+    roomId,
+    transport,
+    signer: createTestSigner("alice"),
+    bufferMs: 0,
+  });
+
+  const bob = createYjsSync({
+    doc: bobDoc,
+    namespace: "demo",
+    roomId,
+    transport,
+    signer: createTestSigner("bob"),
+    bufferMs: 0,
+  });
+
+  await alice.initialize();
+  await bob.initialize();
+
+  aliceDoc.getMap("meta").set("title", "Alpha");
+  bobDoc.getMap("meta").set("status", "draft");
+
+  await Promise.all([alice.flush(), bob.flush()]);
+  await tick();
+
+  assert.equal(aliceDoc.getMap("meta").get("title"), "Alpha");
+  assert.equal(aliceDoc.getMap("meta").get("status"), "draft");
+  assert.equal(bobDoc.getMap("meta").get("title"), "Alpha");
+  assert.equal(bobDoc.getMap("meta").get("status"), "draft");
+
+  alice.destroy();
+  bob.destroy();
+});
+
+test("checkpoint plus tail replay restores current state", async () => {
+  const transport = createInMemoryTransport();
+  const roomId = createRoomId("demo", "entity:county-line");
+
+  const aliceDoc = new Y.Doc();
+  const alice = createYjsSync({
+    doc: aliceDoc,
+    namespace: "demo",
+    roomId,
+    transport,
+    signer: createTestSigner("alice"),
+    bufferMs: 0,
+  });
+
+  await alice.initialize();
+
+  aliceDoc.getMap("entity").set("name", "County Line");
+  await alice.flush();
+  await alice.publishCheckpoint({ reason: "compaction" });
+
+  aliceDoc.getMap("entity").set("location", "Phoenix");
+  await alice.flush();
+
+  const replayDoc = new Y.Doc();
+  const replay = createYjsSync({
+    doc: replayDoc,
+    namespace: "demo",
+    roomId,
+    transport,
+    signer: createTestSigner("replay"),
+    bufferMs: 0,
+  });
+
+  await replay.initialize();
+
+  assert.equal(replayDoc.getMap("entity").get("name"), "County Line");
+  assert.equal(replayDoc.getMap("entity").get("location"), "Phoenix");
+
+  alice.destroy();
+  replay.destroy();
+});
+
+test("host rejection prevents unauthorized live update application", async () => {
+  const transport = createInMemoryTransport();
+  const roomId = createRoomId("demo", "page:about");
+
+  const aliceDoc = new Y.Doc();
+  const viewerDoc = new Y.Doc();
+
+  const alice = createYjsSync({
+    doc: aliceDoc,
+    namespace: "demo",
+    roomId,
+    transport,
+    signer: createTestSigner("alice"),
+    bufferMs: 0,
+  });
+
+  const viewer = createYjsSync({
+    doc: viewerDoc,
+    namespace: "demo",
+    roomId,
+    transport,
+    signer: createTestSigner("viewer"),
+    bufferMs: 0,
+    acceptEvent: (event) => event.pubkey === "pubkey:bob",
+  });
+
+  await alice.initialize();
+  await viewer.initialize();
+
+  aliceDoc.getText("body").insert(0, "should not apply");
+  await alice.flush();
+  await tick();
+
+  assert.equal(viewerDoc.getText("body").toString(), "");
+
+  alice.destroy();
+  viewer.destroy();
+});
+
+test("codec uses queryable single-letter tags", async () => {
+  const roomId = createRoomId("demo", "page:home");
+  const event = createUnsignedEvent({
+    namespace: "demo",
+    roomId,
+    messageType: "update",
+    payloadBytes: new Uint8Array([1, 2, 3]),
+  });
+
+  const decoded = decodeEvent({
+    ...event,
+    pubkey: "pubkey:test",
+    id: "event-1",
+    sig: "sig:event-1",
+  });
+
+  assert.equal(decoded.namespace, "demo");
+  assert.equal(decoded.roomId, roomId);
+  assert.equal(decoded.messageType, "update");
+
+  const filters = createDocumentFilters({
+    namespace: "demo",
+    roomId,
+  });
+
+  assert.equal(filters[0]["#n"][0], "demo");
+  assert.equal(filters[0]["#d"][0], roomId);
+  assert.equal(filters[0]["#m"][0], "checkpoint");
+});
+
+async function tick() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}


### PR DESCRIPTION
## What changed
- add a minimal Yjs sync layer over a small Nostr-style transport adapter
- add event codec, replay helpers, buffered update publishing, checkpoints, and checkpoint requests
- tighten the protocol docs to use queryable single-letter tags for relay filters
- add in-memory transport tests instead of depending on public relays

## Validation
- npm run check
- npm test

## Follow-on
- first 
ostr-site integration is tracked in 
ostr-site#27

Closes #3

CC @Aux0x7F