### PR TITLE
Expose package entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "description": "Browser-first CRDT transport over Nostr",
   "license": "MIT",
   "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
   "scripts": {
     "check": "node --check src/index.js && node --check src/codec.js && node --check src/yjs-sync.js && node --check test/helpers/in-memory-transport.js && node --check test/nostr-crdt.test.js",
     "test": "node --test test/nostr-crdt.test.js"


### PR DESCRIPTION
## What changed
- add explicit package entry metadata so other repos can import 
ostr-crdt cleanly

## Validation
- npm run check
- npm test

Closes #5

CC @Aux0x7F