### PR TITLE
Lean CRDT document query filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "0.0.0",
   "description": "Browser-first CRDT transport over Nostr",
-  "license": "MIT",
   "type": "module",
   "main": "./src/index.js",
   "exports": {

--- a/src/codec.js
+++ b/src/codec.js
@@ -154,8 +154,6 @@ export function normalizeMessageType(value) {
 function createFilter(kind, namespace, roomId, messageType) {
   return {
     kinds: [Number(kind)],
-    "#t": ["crdt"],
-    "#n": [namespace],
     "#d": [roomId],
     "#m": [normalizeMessageType(messageType)],
   };

--- a/test/nostr-crdt.test.js
+++ b/test/nostr-crdt.test.js
@@ -203,7 +203,6 @@ test("codec uses queryable single-letter tags", async () => {
     roomId,
   });
 
-  assert.equal(filters[0]["#n"][0], "demo");
   assert.equal(filters[0]["#d"][0], roomId);
   assert.equal(filters[0]["#m"][0], "checkpoint");
 });


### PR DESCRIPTION
Closes #7\n\nThis keeps document queries smaller and more relay-compatible by dropping extra tag filters from the query path and updating the codec test to match.