### PR TITLE
Verify CRDT events before apply

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -20,7 +20,7 @@ The first implementation target is Yjs, but the API should be shaped so the repo
 - replay and catch-up helpers
 - buffered update publishing
 - checkpoint publishing and replay helpers
-- host hooks for signer acceptance policy
+- host hooks for signature verification and signer acceptance policy
 - a transport adapter contract that does not require a specific Nostr client library
 
 `nostr-crdt` should not provide:
@@ -53,6 +53,7 @@ The host application must provide:
 
 - relay configuration
 - signer identity and signing
+- signature verification policy for incoming messages
 - acceptance policy for incoming messages
 - document ownership and namespace policy
 
@@ -78,6 +79,7 @@ Required test shapes:
 - one-writer replay
 - two-writer convergence
 - checkpoint plus tail replay
+- ignored update from a signature-verification failure
 - ignored update from a host-rejected signer
 
 ## Transport adapter

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -64,7 +64,7 @@ Recommended tags:
 - `["c", "yjs-update-v1"]`
 - `["x", "<checkpoint-id>"]` when applicable
 
-The event `pubkey` is the signer identity. The transport does not decide whether that signer is trusted; the host application does.
+The event `pubkey` is the signer identity. The host application or adapter must also verify the event signature before the message is considered eligible for replay or live apply.
 
 ## Payload
 
@@ -94,9 +94,9 @@ Notes:
 
 ## Client acceptance rules
 
-The transport layer validates the event shape and verifies the Nostr signature.
+The transport layer validates the event shape. Signature verification and signer acceptance are host-controlled so the library can stay transport-agnostic.
 
-The host application decides whether to apply the update. `nostr-crdt` should expose hooks for host-provided authorization and acceptance policy.
+The host application decides whether to apply the update. `nostr-crdt` should expose hooks for host-provided signature verification, authorization, and acceptance policy.
 
 ## Replay and catch-up
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ const sync = createYjsSync({
   roomId,
   transport,
   signer,
+  verifyEvent(event) {
+    return event.sig === `sig:${event.id}`;
+  },
   acceptEvent(event, decoded) {
     return trustedAdminSet.has(decoded.event.pubkey);
   },
@@ -67,6 +70,11 @@ The transport adapter is intentionally small:
 - `query(filters)`
 - `subscribe(filters, onEvent)`
 - `publish(event)`
+
+Optional host hooks stay explicit:
+
+- `verifyEvent(event)`
+- `acceptEvent(event, decoded)`
 
 ## Documents
 

--- a/src/yjs-sync.js
+++ b/src/yjs-sync.js
@@ -22,6 +22,7 @@ export class YjsNostrSync {
     signer,
     kind = DEFAULT_EVENT_KIND,
     bufferMs = 100,
+    verifyEvent = () => true,
     acceptEvent = () => true,
     onCheckpointRequest = null,
   }) {
@@ -43,6 +44,7 @@ export class YjsNostrSync {
     this.transport = transport;
     this.signer = signer;
     this.bufferMs = Math.max(0, Number(bufferMs) || 0);
+    this.verifyEvent = verifyEvent;
     this.acceptEvent = acceptEvent;
     this.onCheckpointRequest = onCheckpointRequest;
 
@@ -174,6 +176,7 @@ export class YjsNostrSync {
   async handleTransportEvent(event) {
     if (this.destroyed) return;
     if (event?.id && this.seenEventIds.has(event.id)) return;
+    if (!(await this.isVerifiedEvent(event))) return;
 
     let decoded;
     try {
@@ -231,6 +234,7 @@ export class YjsNostrSync {
 
     for (const event of ordered) {
       if (event?.id && this.seenEventIds.has(event.id)) continue;
+      if (!(await this.isVerifiedEvent(event))) continue;
 
       let decoded;
       try {
@@ -248,6 +252,14 @@ export class YjsNostrSync {
     }
 
     return accepted;
+  }
+
+  async isVerifiedEvent(event) {
+    return Boolean(
+      await Promise.resolve(
+        typeof this.verifyEvent === "function" ? this.verifyEvent(event) : this.verifyEvent
+      )
+    );
   }
 }
 

--- a/test/nostr-crdt.test.js
+++ b/test/nostr-crdt.test.js
@@ -178,6 +178,56 @@ test("host rejection prevents unauthorized live update application", async () =>
   viewer.destroy();
 });
 
+test("signature verification rejects invalid replay and live events", async () => {
+  const transport = createInMemoryTransport();
+  const roomId = createRoomId("demo", "page:home");
+  const verifyEvent = (event) => event?.sig === `sig:${event?.id}`;
+
+  const replayEvent = await createTestSigner("alice").sign(
+    createUnsignedEvent({
+      namespace: "demo",
+      roomId,
+      messageType: "update",
+      payloadBytes: Y.encodeStateAsUpdate(createDocWithText("replay should fail")),
+    })
+  );
+  await transport.publish({
+    ...replayEvent,
+    sig: "sig:invalid-replay",
+  });
+
+  const doc = new Y.Doc();
+  const sync = createYjsSync({
+    doc,
+    namespace: "demo",
+    roomId,
+    transport,
+    signer: createTestSigner("viewer"),
+    verifyEvent,
+    bufferMs: 0,
+  });
+
+  await sync.initialize();
+  assert.equal(doc.getText("body").toString(), "");
+
+  const liveEvent = await createTestSigner("alice").sign(
+    createUnsignedEvent({
+      namespace: "demo",
+      roomId,
+      messageType: "update",
+      payloadBytes: Y.encodeStateAsUpdate(createDocWithText("live should fail")),
+    })
+  );
+  await transport.publish({
+    ...liveEvent,
+    sig: "sig:invalid-live",
+  });
+  await tick();
+
+  assert.equal(doc.getText("body").toString(), "");
+  sync.destroy();
+});
+
 test("codec uses queryable single-letter tags", async () => {
   const roomId = createRoomId("demo", "page:home");
   const event = createUnsignedEvent({
@@ -209,4 +259,10 @@ test("codec uses queryable single-letter tags", async () => {
 
 async function tick() {
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createDocWithText(value) {
+  const doc = new Y.Doc();
+  doc.getText("body").insert(0, value);
+  return doc;
 }


### PR DESCRIPTION
## Summary
- add a dedicated verification hook before replayed or live CRDT events are accepted
- document the signature-verification responsibility in the library contracts
- cover invalid replay and live events in the in-memory test suite

Closes #9